### PR TITLE
Onet link url updated to https

### DIFF
--- a/app/src/main/res/xml/providers.xml
+++ b/app/src/main/res/xml/providers.xml
@@ -259,7 +259,7 @@
     <!-- no IMAP IDLE -->
     <provider
         name="Onet"
-        link="http://m.poczta.onet.pl/pomoc/android.html">
+        link="https://m.poczta.onet.pl/pomoc/android.html">
         <imap
             host="imap.poczta.onet.pl"
             port="993"


### PR DESCRIPTION
The link to Onet was using only insecure http. The same URL with HTTPS works therefore I recommend to change it to https.